### PR TITLE
Add headsparallel flow and optional sampling flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This will place `data/input.txt` (Tiny Shakespeare) into the `data/` folder.
 python -m toygpt.train
 ```
 
-By default it runs for 5000 iterations and prints losses every 300 steps. A checkpoint is saved to `checkpoints/ckpt.pt` at the end of training.
+By default it runs for 5100 iterations and prints losses every 300 steps. A checkpoint is saved to `checkpoints/ckpt.pt` at the end of training.
 
 > Want a quick sanity sample after training? Append `--sample` to generate text immediately:
 >
@@ -87,7 +87,13 @@ By default it runs for 5000 iterations and prints losses every 300 steps. A chec
 > python -m toygpt.train --sample
 > ```
 
-> **Expected (reported) final losses:** `train loss 1.6604, val loss 1.8520`  
+> Need to keep training? Use `--resume` to pick up from the latest checkpoint and optionally pass `--steps` to control how many additional optimization steps to run (defaults to 5000 per invocation):
+>
+> ```bash
+> python -m toygpt.train --resume --steps 2000
+> ```
+
+> **Expected (reported) final losses:** `train loss 1.6527, val loss 1.8550`  
 > Exact numbers can vary slightly by hardware/seed.
 
 ### 5) Generate text
@@ -112,8 +118,8 @@ git push -u origin main
 ## Hyperparameters (defaults)
 
 - `batch_size = 32`
-- `block_size = 8`
-- `max_iters = 5000`
+- `block_size = 16`
+- `max_iters = 5100`
 - `eval_interval = 300`
 - `learning_rate = 1e-3`
 - `eval_iters = 200`


### PR DESCRIPTION
Summary

Refactored self-attention so all heads run in parallel within MultiHeadAttention, mirroring the nanoGPT approach and documenting tensor shapes along the way.
Added --sample, --resume, and --steps flags to toygpt.train so runs can optionally emit text, reload checkpoints, and continue for custom step counts.
Bumped block_size to 16 and refreshed README defaults plus reported losses to match the new training setup.
Replaced the placeholder smoke test with a MyCustomToyGPT forward-pass check to guard logits shape and loss computation.

Testing
python -m pytest tests/test_model_forward.py (run once pytest installed in the active env).
